### PR TITLE
Update to Debian Bullseye

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ stages:
   - job: build_container_emulated
     displayName: Build container for architecture
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     strategy:
       matrix:
         armhf:
@@ -36,7 +36,7 @@ stages:
   - job: build_container_powerpc
     displayName: Build container for PowerPC
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     steps:
     - script: docker run --rm --privileged multiarch/qemu-user-static:register --reset
       displayName: Register QEMU wrappers

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
     - checkout: self
       fetchDepth: 1
     - script: |
-        docker build -t "pqclean/ci-container:$(arch)" --build-arg "ARCH=$(arch)" debian-buster
+        docker build -t "pqclean/ci-container:$(arch)" --build-arg "ARCH=$(arch)" debian-bullseye
       displayName: Build container
     - script: |
         docker login --username $(dockerUsername) --password "$(dockerPassword)"

--- a/debian-bullseye/Dockerfile
+++ b/debian-bullseye/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH
-FROM multiarch/debian-debootstrap:${ARCH}-buster
+FROM multiarch/debian-debootstrap:${ARCH}-bullseye
 
 RUN apt-get update -qq \
  && apt-get upgrade -y \
@@ -7,7 +7,9 @@ RUN apt-get update -qq \
 # Install build dependencies
  && apt-get install -y -q \
         astyle \
+        clang \
         clang-tidy \
+        gcc \
         git-core \
         make \
         python3-dev \
@@ -18,11 +20,6 @@ RUN apt-get update -qq \
         python3-rednose \
         python3-yaml \
         valgrind \
- # Install GCC 9
- && echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list \
- && echo "deb http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
- && apt-get update -qq \
- && apt-get -t experimental install -y -q gcc clang \
  && apt-get autoremove -y \
 # Cleanup
  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*


### PR DESCRIPTION
The new _testing_ release of Debian has the GCC and Clang compilers we
need and won't install experimental versions of compilers and tools.