### PR TITLE
Disable clang-tidy on ppc

### DIFF
--- a/debian-unstable-ppc/Dockerfile
+++ b/debian-unstable-ppc/Dockerfile
@@ -2,10 +2,10 @@ FROM pqclean/multiarch-debian-debootstrap:powerpc-sid
 
 COPY ppc-sources.list /etc/apt/sources.list
 
-RUN wget http://ftp.ports.debian.org/debian-ports/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_2019.11.05_all.deb \
+RUN wget http://ftp.ports.debian.org/debian-ports/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_2021.12.30_all.deb \
 # Install debian-ports keychain
- && dpkg -i debian-ports-archive-keyring_2019.11.05_all.deb \
- && rm debian-ports-archive-keyring_2019.11.05_all.deb \
+ && dpkg -i debian-ports-archive-keyring_2021.12.30_all.deb \
+ && rm debian-ports-archive-keyring_2021.12.30_all.deb \
 # Update to unstable
  && apt-get update -qq \
  && apt-get upgrade -q -y \

--- a/debian-unstable-ppc/Dockerfile
+++ b/debian-unstable-ppc/Dockerfile
@@ -2,6 +2,8 @@ FROM pqclean/multiarch-debian-debootstrap:powerpc-sid
 
 COPY ppc-sources.list /etc/apt/sources.list
 
+ENV PQCLEAN_SKIP_TESTS=clang_tidy
+
 RUN wget http://ftp.ports.debian.org/debian-ports/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_2021.12.30_all.deb \
 # Install debian-ports keychain
  && dpkg -i debian-ports-archive-keyring_2021.12.30_all.deb \


### PR DESCRIPTION
Let's no longer run clang-tidy on PPC builds, as they run on debian unstable.
